### PR TITLE
Adjust capability needed to display admin menu

### DIFF
--- a/ASU-CAS-Maestro-WordPress-Plugin.php
+++ b/ASU-CAS-Maestro-WordPress-Plugin.php
@@ -125,7 +125,7 @@ Welcome aboard!',
     // Get blog settings. If they doesn't exist, get the network settings.
     $this->settings = get_option( 'asuCAS_settings',$this->network_settings );
     $this->allowed_users = get_option( 'asuCAS_allowed_users',array() );
-    $this->change_users_capability = 'edit_posts';
+    $this->change_users_capability = 'manage_options';
 
     if ( ! isset( $_SESSION ) ) {
       session_start();


### PR DESCRIPTION
Setting default capability of the plugin to look for "manage_options" to display any aspect of the admin menu.

Previous setting was `edit_posts` which allowed contributors and above to be able to see the admin menu and at least one of the metaboxes within. That could possibly lead to privilege escalation:

- The metabox in question allowed for the current user to set up other users as administrators upon initial login.
- Including possibly themselves or another compromised account.
- 
![image](https://user-images.githubusercontent.com/2085753/149394053-0115b574-9cdf-48a5-8fdf-1091c5224bac.png)
